### PR TITLE
Install NPM

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -26,6 +26,7 @@ in {
       pkgs.curl
       pkgs.libiconv
       pkgs.watchman
+      pkgs.nodePackages.npm
     ];
 
     emberPkgs = if super.system == "x86_64-darwin" then


### PR DESCRIPTION
This is to facilitate an experiment to cut over to npm over yarn.

(NOTE: npm v6 is already installed, this ensures npm v7 is installed)