### PR TITLE
Upgrade NodeJS

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,7 @@ in {
     basePackages = [
       self.yarn
       pkgs.python
-      pkgs.nodejs-14_x
+      pkgs.nodejs-16_x
       pkgs.gnumake
       pkgs.gcc
       pkgs.readline


### PR DESCRIPTION
Modern Ember CLI supports Node 16. Let's use it.